### PR TITLE
SKIP-123: v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.1
+
+- remove `release` Github workflow since this repository does not package the library
+- change namespace to `@productboard/`
+
 ## v1.9.0
 
 - `must-colocate-fragment-spreads` rule now accepts the optional `allowNamedImports` option that can be set to true (defaults to false) to allow marking a fragment as used when there is a matching named import:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@productboard/eslint-plugin-relay",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "https://github.com/productboard/eslint-plugin-relay",


### PR DESCRIPTION
Bump version

Changelog:

- remove `release` Github workflow since this repository does not package the library
- change namespace to `@productboard/`
