### PR TITLE
SKIP-123: v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.2
+
+- fix inability to use `disable-next-line` comments
+
 ## v1.9.1
 
 - remove `release` Github workflow since this repository does not package the library

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The following rules support suppression within graphql tags:
 - relay/unused-fields
 - relay/must-colocate-fragment-spreads
 
-Supported rules can be suppressed by adding `# eslint-disable-next-line relay/name-of-rule` to the preceding line:
+Supported rules can be suppressed by adding `# eslint-disable-next-line @productboard/relay/name-of-rule` to the preceding line:
 
 ```js
 graphql`fragment foo on Page {
-  # eslint-disable-next-line relay/must-colocate-fragment-spreads
+  # eslint-disable-next-line @productboard/relay/must-colocate-fragment-spreads
   ...unused1
 }`
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@productboard/eslint-plugin-relay",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "https://github.com/productboard/eslint-plugin-relay",

--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -61,7 +61,7 @@ const {visit} = require('graphql');
 const utils = require('./utils');
 
 const ESLINT_DISABLE_COMMENT =
-  ' eslint-disable-next-line relay/must-colocate-fragment-spreads';
+  ' eslint-disable-next-line @productboard/relay/must-colocate-fragment-spreads';
 
 function getGraphQLFragmentSpreads(graphQLAst) {
   const fragmentSpreads = {};

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -13,7 +13,8 @@ const {
   hasPrecedingEslintDisableComment
 } = require('./utils');
 
-const ESLINT_DISABLE_COMMENT = ' eslint-disable-next-line relay/unused-fields';
+const ESLINT_DISABLE_COMMENT =
+  ' eslint-disable-next-line @productboard/relay/unused-fields';
 
 function getGraphQLFieldNames(graphQLAst) {
   const fieldNames = {};

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -112,7 +112,7 @@ ruleTester.run(
       ',
       `
       graphql\`fragment foo on Page {
-        # eslint-disable-next-line relay/must-colocate-fragment-spreads
+        # eslint-disable-next-line @productboard/relay/must-colocate-fragment-spreads
         ...unused1
       }\`;
       `

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -86,7 +86,7 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     `,
     `
       graphql\`fragment foo on Page {
-        # eslint-disable-next-line relay/unused-fields
+        # eslint-disable-next-line @productboard/relay/unused-fields
         name
       }\`;
     `


### PR DESCRIPTION
Changelog:

- fix inability to use `disable-next-line` comments
