### PR TITLE
PD-151: do not report unused node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.9.4
+## v1.9.6
 
 - rule `unused-fields` has additional functionality which allows you to pass option `edgesAndNodesWhiteListFunctionName`, this is a name of a function and if that function receives an object with `edges` as argument, it will ignore `edges` and `node` warning for unused fields because it considers them to be used inside this function
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.4
+
+- rule `unused-fields` has additional functionality which allows you to pass option `edgesAndNodesWhiteListFunctionName`, this is a name of a function and if that function receives an object with `edges` as argument, it will ignore `edges` and `node` warning for unused fields because it considers them to be used inside this function
+
 ## v1.9.3
 
 - allow to pass custom error message to `no-future-added-value` rule

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@productboard/eslint-plugin-relay",
   "private": true,
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "https://github.com/productboard/eslint-plugin-relay",

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -166,8 +166,7 @@ function rule(context) {
   // `edgesAndNodesWhiteListFunctionName` contains arguments
   // that are property accesses on a field that contains
   // `edges`
-  function shouldIgnoreWhiteListedCollectConnectionFields(
-    field,
+  function wasWhiteListFunctionCalledWithEdgesAndNodesArgument(
     edgesParents,
     callArguments
   ) {
@@ -179,7 +178,17 @@ function rule(context) {
       )
     );
 
-    return (field === 'edges' || field === 'node') && intersect.size > 0;
+    return intersect.size > 0;
+  }
+
+  function shouldIgnoreWhiteListedCollectConnectionFields(
+    field,
+    whiteListFunctionCalledWithEdgesAndNodes
+  ) {
+    return (
+      (field === 'edges' || field === 'node') &&
+      whiteListFunctionCalledWithEdgesAndNodes
+    );
   }
 
   return {
@@ -203,6 +212,12 @@ function rule(context) {
         const {fieldNames: queriedFields, edgesParents} =
           getGraphQLFieldNames(graphQLAst);
 
+        const whiteListFunctionCalledWithEdgesAndNodes =
+          wasWhiteListFunctionCalledWithEdgesAndNodesArgument(
+            edgesParents,
+            edgesAndNodesWhiteListFunctionCallArguments
+          );
+
         for (const field in queriedFields) {
           if (
             !foundMemberAccesses[field] &&
@@ -212,8 +227,7 @@ function rule(context) {
             field !== '__typename' &&
             !shouldIgnoreWhiteListedCollectConnectionFields(
               field,
-              edgesParents,
-              edgesAndNodesWhiteListFunctionCallArguments
+              whiteListFunctionCalledWithEdgesAndNodes
             )
           ) {
             context.report({

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -149,7 +149,14 @@ function rule(context) {
 
   function getEdgesAndNodesWhiteListFunctionCallArguments(calls) {
     return calls.flatMap(call =>
-      call.arguments.map(arg => (arg.property ? arg.property.name : null))
+      call.arguments.map(arg => {
+        if ('expression' in arg) {
+          return arg.expression.property.name;
+        } else if ('property' in arg) {
+          return arg.property.name;
+        }
+        return null;
+      })
     );
   }
 

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -150,7 +150,9 @@ function rule(context) {
   function getEdgesAndNodesWhiteListFunctionCallArguments(calls) {
     return calls.flatMap(call =>
       call.arguments.map(arg => {
-        if ('expression' in arg) {
+        if (arg.type === 'Identifier') {
+          return arg.name;
+        } else if ('expression' in arg) {
           return arg.expression.property.name;
         } else if ('property' in arg) {
           return arg.property.name;

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -156,8 +156,52 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     }\`;
 
     const nodes = collectConnectionNodes(data.fields);
+    const firstNode = nodes[0].id;
 
-    const ids = nodes.map((node) => node.id);
+    const connectionId = data.fields.__id;
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        __id
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data?.fields);
+    const firstNode = nodes[0].id;
+
+    const connectionId = data.fields.__id;
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    },
+    {
+      code: `
+    graphql\`query fields($id: ID!) {
+      node(id: $id) {
+        fields {
+          __id
+          edges {
+            node {
+              __typename
+              id
+            }
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.node.fields);
+    const firstNode = nodes[0].id;
+
     const connectionId = data.fields.__id;
     `,
       options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
@@ -307,6 +351,28 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     `,
       options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}],
       errors: [
+        {
+          message: unusedFieldsWarning('name'),
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        name
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.unrelatedData);
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}],
+      errors: [
+        {
+          message: unusedFieldsWarning('fields'),
+          line: 3
+        },
         {
           message: unusedFieldsWarning('name'),
           line: 4

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -140,6 +140,27 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     const otherIds = otherNodes.map((node) => node.id);
     `,
       options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        __id
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.fields);
+
+    const ids = nodes.map((node) => node.id);
+    const connectionId = data.fields.__id;
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
     }
   ],
   invalid: [

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -90,7 +90,8 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         name
       }\`;
     `,
-    `
+    {
+      code: `
     graphql\`fragment foo on Page {
       fields {
         edges {
@@ -105,7 +106,9 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     const nodes = collectConnectionNodes(data.fields);
 
     const ids = nodes.map((node) => node.id);
-    `
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    }
   ],
   invalid: [
     {
@@ -197,6 +200,35 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
 
     const ids = nodes.map((node) => node.id);
     `,
+      errors: [
+        {
+          message: unusedFieldsWarning('edges'),
+          line: 4
+        },
+        {
+          message: unusedFieldsWarning('node'),
+          line: 5
+        }
+      ]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes_TYPO(data.fields);
+
+    const ids = nodes.map((node) => node.id);
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}],
       errors: [
         {
           message: unusedFieldsWarning('edges'),

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -108,6 +108,38 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     const ids = nodes.map((node) => node.id);
     `,
       options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+    graphql\`fragment bar on Page {
+      items {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.fields);
+
+    const ids = nodes.map((node) => node.id);
+
+    const otherNodes = collectConnectionNodes(data.items);
+
+    const otherIds = otherNodes.map((node) => node.id);
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
     }
   ],
   invalid: [
@@ -237,6 +269,26 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         {
           message: unusedFieldsWarning('node'),
           line: 5
+        }
+      ]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        name
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.fields);
+
+    const ids = nodes.map((node) => node.id);
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}],
+      errors: [
+        {
+          message: unusedFieldsWarning('name'),
+          line: 4
         }
       ]
     }

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -185,6 +185,28 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
     },
     {
       code: `
+    graphql\`fragment foo on Page {
+      fields {
+        __id
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const { fields } = data;
+    const nodes = collectConnectionNodes(fields);
+    const firstNode = nodes[0].id;
+
+    const connectionId = fields.__id;
+    `,
+      options: [{edgesAndNodesWhiteListFunctionName: 'collectConnectionNodes'}]
+    },
+    {
+      code: `
     graphql\`query fields($id: ID!) {
       node(id: $id) {
         fields {

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -89,6 +89,22 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         # eslint-disable-next-line @productboard/relay/unused-fields
         name
       }\`;
+    `,
+    `
+    graphql\`fragment foo on Page {
+      fields {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = collectConnectionNodes(data.fields);
+
+    const ids = nodes.map((node) => node.id);
     `
   ],
   invalid: [
@@ -161,6 +177,34 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         {
           message: unusedFieldsWarning('unused2'),
           line: 4
+        }
+      ]
+    },
+    {
+      code: `
+    graphql\`fragment foo on Page {
+      fields {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+      }
+    }\`;
+
+    const nodes = filterSomeData(data.fields);
+
+    const ids = nodes.map((node) => node.id);
+    `,
+      errors: [
+        {
+          message: unusedFieldsWarning('edges'),
+          line: 4
+        },
+        {
+          message: unusedFieldsWarning('node'),
+          line: 5
         }
       ]
     }


### PR DESCRIPTION
This PR adds configuration to `unused-fields` rule which allows you to specify utility function that processes fields with `edges` on them. If this utility is present in source file and this specific argument is passed there, it won't trigger warnings (or errors) for unused `edges` and `node` field because it assumes this utility function is using them.

This should avoid disabling this lint rule in places where such utilities are used. It must be a standalone function (no property access) whose name must match to rule option `edgesAndNodesWhiteListFunctionName`, only single function can be specified and its hardcoded to ignore only `node` and `edges` fields, nothing else.