### PR TITLE
Fix issue with reporting the @productboard/relay/unused-fields is unused

### DIFF
--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -197,7 +197,7 @@ function rule(context) {
       foundMemberAccesses = {};
       templateLiterals = [];
     },
-    'Program:exit'(_node) {
+    'Program:exit'(node) {
       const edgesAndNodesWhiteListFunctionCallArguments =
         getEdgesAndNodesWhiteListFunctionCallArguments(
           edgesAndNodesWhiteListFunctionCalls
@@ -231,7 +231,7 @@ function rule(context) {
             )
           ) {
             context.report({
-              node: templateLiteral,
+              node,
               loc: getLoc(context, templateLiteral, queriedFields[field]),
               message:
                 `This queries for the field \`${field}\` but this file does ` +


### PR DESCRIPTION
Fixes issue with eslint reporting the rule is unused, altough it's reporting errors.
