### PR TITLE
Remove case sensitivity for collocate fragment spreads

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -103,10 +103,6 @@ function getGraphQLFragmentSpreads(graphQLAst) {
   return fragmentSpreads;
 }
 
-function isFirstLetterUppercase(word) {
-  return /^\p{Lu}/u.test(word);
-}
-
 function getGraphQLFragmentDefinitionName(graphQLAst) {
   let name = null;
   visit(graphQLAst, {
@@ -171,11 +167,7 @@ function checkColocation(context) {
     ImportDeclaration(node) {
       if (node.importKind === 'value') {
         node.specifiers.forEach(specifier => {
-          if (
-            allowNamedImports &&
-            specifier.imported &&
-            isFirstLetterUppercase(specifier.imported.name)
-          ) {
+          if (allowNamedImports && specifier.imported) {
             foundImportedModules.push({
               type: 'namedImport',
               value: specifier.imported.name

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -50,6 +50,16 @@ ruleTester.run(
         `,
         options: [{allowNamedImports: true}]
       },
+      {
+        code: `
+          import { useHook } from '@some/module';
+          
+          graphql\`fragment foo on Page {
+            ...useHook
+          }\`;
+          `,
+        options: [{allowNamedImports: true}]
+      },
       `
       const Component = require('../shared/component.js');
       graphql\`fragment foo on Page {


### PR DESCRIPTION
The problem is that we use fragments also in hook and those don't start with the first capital letter therefore I removed the check.

Sorry @comatory , I noticed your [PR here](https://github.com/productboard/eslint-plugin-relay/pull/12) after I made these changes and I saw you didn't have test so I would suggest merging mine :-)